### PR TITLE
Add spectrogram interaction and sound saving

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         <button id="startRec">Start Recording</button>
         <button id="stopRec" disabled>Stop Recording</button>
         <button id="playRec" disabled>Play Recording</button>
+        <button id="saveSound" disabled>Save Sound</button>
     </div>
     <div class="edit">
         <label>Trim Start (s): <input type="number" id="trimStart" value="0" step="0.1" min="0"></label>
@@ -20,6 +21,10 @@
     </div>
     <button id="export" disabled>Export WAV</button>
     <canvas id="spectrogram" width="800" height="256"></canvas>
+    <div id="sidebar">
+        <h3>Saved Sounds</h3>
+        <ul id="savedList"></ul>
+    </div>
 
     <script src="script.js"></script>
 </body>

--- a/style.css
+++ b/style.css
@@ -14,3 +14,19 @@ canvas {
 #export {
     margin: 5px;
 }
+
+#sidebar {
+    text-align: left;
+    margin-top: 20px;
+    max-height: 200px;
+    overflow-y: auto;
+    border: 1px solid #ccc;
+    padding: 10px;
+    display: inline-block;
+}
+
+#savedList li button {
+    display: block;
+    margin: 2px 0;
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- allow dragging and zooming in the spectrogram with mouse events
- press Ctrl+Click to select a timestamp and show a red indicator line
- enable play/pause with space bar
- add Save button and sidebar for saved sounds
- store sounds in `localStorage` and load them on demand

## Testing
- `node -c script.js`

------
https://chatgpt.com/codex/tasks/task_e_68688bf00f0483208a3ec4891b26cb83